### PR TITLE
libnotify path corrected for Ubuntu 10.10

### DIFF
--- a/irssi-notify-listener.py
+++ b/irssi-notify-listener.py
@@ -752,7 +752,7 @@ __UPDATED__     = '''Last update: Wed May 05 15:27:48 CEST 2010
                   '''
 
 NOTIFIER_GROWL = '/usr/local/bin/growlnotify'
-NOTIFIER_DBUS  = '/usr/bin/notify'
+NOTIFIER_DBUS  = '/usr/bin/notify-send'
 HOST = 'localhost'
 PORT = 4222
 


### PR DESCRIPTION
Thanks for the hard work, working great here with Irssi on my Arch server and Ubuntu 10.10 clientside.
