### PR TITLE
Remove die() from notify.pl and load host/port from Irssi settings

### DIFF
--- a/notify.pl
+++ b/notify.pl
@@ -25,8 +25,8 @@ sub notify {
 
     my $remote = IO::Socket::INET->new(
                         Proto    => "tcp",
-                        PeerAddr => "localhost",
-                        PeerPort => "4222",
+                        PeerAddr => Irssi::settings_get_str('notify-listener_host'),
+                        PeerPort => Irssi::settings_get_int('notify-listener_port'),
                     )
                   or do {
 			print("notify.pl: cannot connect to notification daemon");
@@ -64,6 +64,11 @@ sub dcc_request_notify {
     notify($server, "DCC ".$dcc->{type}." request", $dcc->{nick});
 }
 
+# Register settings
+Irssi::settings_add_int('misc', 'notify-listener_port', 4222);
+Irssi::settings_add_str('misc', 'notify-listener_host', 'localhost');
+
+# Register signals
 Irssi::signal_add('print text', 'print_text_notify');
 Irssi::signal_add('message private', 'message_private_notify');
 Irssi::signal_add('dcc request', 'dcc_request_notify');


### PR DESCRIPTION
Two quick changes to the notify.pl script:
1. Whenever notify.pl is unable to connect to the socket it calls die(), causing the script to die, i.e. no more notifications would be issued. Now we just print a message and return. This allows me to use this even when running irssi in a screen/tmux session.
2. Instead of having the host/port hardcoded in notify.pl, load them from Irssi settings.

Hopefully I haven't introduced any bugs - I'm kind of bad at Perl :D
