### PR TITLE
Fix linux (gnome shell) icon and notification grouping

### DIFF
--- a/notossh/notossh.py
+++ b/notossh/notossh.py
@@ -964,9 +964,9 @@ def notify_growl(opts, cmd_opts, args):
 
     growl_command = None
     if opts.sticky is True:
-        growl_command = subprocess.Popen([opts.growl, '-s', '-n', 'Terminal', '--image', 'irssi.icns', '-m', ':'.join(args[1:]), args[0]])
+        growl_command = [opts.growl, '-s', '-n', 'Terminal', '--image', 'irssi.icns', '-m', ':'.join(args[1:]), args[0]]
     else:
-        growl_command = subprocess.Popen([opts.growl, '-n', 'Terminal', '--image', 'irssi.icns', '-m', ':'.join(args[1:]), args[0]])
+        growl_command = [opts.growl, '-n', 'Terminal', '--image', 'irssi.icns', '-m', ':'.join(args[1:]), args[0]]
 
     return subprocess.Popen(growl_command)
 


### PR DESCRIPTION
This branch contains fixes for Gnome shell including the following:
- fixes irssi icon temporary folder path
- replaces use of "notify-send" command with use of a conditional import of the GTK gi.respository.Notify api
  - implements use of categorization and groups messages together under the name "irssi"

For Linux window managers other than Gnome Shell, this may break notifications entirely, but I have not tested.
Changes to the growl section tested on Mac OSX Mountain Lion.
I also have not updated the command-line help output.
