### PR TITLE
notify_dbus replace previous notification with the same title

### DIFF
--- a/notossh/notossh.py
+++ b/notossh/notossh.py
@@ -110,13 +110,30 @@ def notify_terminal(opts, cmd_opts, args):
     return subprocess.Popen(notifier_command)
 
 
+def memonotify(f):
+    memo = {}
+    def g(*args, **kwargs):
+        title = args[2].split(":")[0]
+        try:
+            n = memo[title]
+        except KeyError:
+            n = None
+        memo[title] = f(*args, n=n, **kwargs)
+        return memo
+    return g
+
+
 # define the command used with linux systems
-def notify_dbus(opts, cmd_opts, args):
+@memonotify
+def notify_dbus(opts, cmd_opts, args, n=None):
     args = args.split(':')
-    n = Notify.Notification.new(':'.join(args[1:]), args[0], os.path.join(WORKDIR, 'irssi.png'))
+    if n is None:
+        n = Notify.Notification.new(args[0], ':'.join(args[1:]), os.path.join(WORKDIR, 'irssi.png'))
+    else:
+        n.update(args[0], ':'.join(args[1:]), os.path.join(WORKDIR, 'irssi.png'))
     n.set_category("im.received")
     n.show()
-    return 0
+    return n
 
 
 def notify_cli(opts, cmd_opts, args):


### PR DESCRIPTION
On linux, when using the dbus notification library, is possible to override the last notification in order to not have many notifications from the same user,
I have a propose that looks at the current summary/title of the notifications, and following notifications with the same title are overridden, for example when receiving 3 notifications like:
PM from me:  "hello"
PM from me: "world"
PM from you: "!"

only two of them are displayed in the notification area, in particular those are shown:

PM from me: "world"
PM from you: "!"

this avoids notifications floods, what do you think?
ps (this pull request should be reviewed also with https://github.com/guyzmo/notossh/pull/9 because there the order of the title and body is inverted, line 116 )

thanks!
