### PR TITLE
Fix LocalCommand

### DIFF
--- a/README
+++ b/README
@@ -77,7 +77,7 @@ to connect to :
 
     Host HOST
     PermitLocalCommand yes
-    LocalCommand "/path/to/bin/notossh start"
+    LocalCommand /path/to/bin/notossh start
     RemoteForward PORT localhost:PORT
 
 NOTIFICATIONS


### PR DESCRIPTION
The quotes around the `LocalCommand` break the configuration in `.ssh/config`. 
This PR fixes it by removing the quotes.

(It might have worked with the quotes in earlier versions of SSH, but does not in my current version.)